### PR TITLE
Refactor revalidate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,8 +19,4 @@ jobs:
         run: yarn lint
 
       - name: Build
-        env:
-          GOOGLE_CREDS: ${{ secrets.GOOGLE_CREDS }}
-          GOOGLE_PRIVATE_CREDS: ${{ secrets.GOOGLE_PRIVATE_CREDS }}
-          SHARED_GOOGLE_DRIVE_ID: ${{ secrets.SHARED_GOOGLE_DRIVE_ID }}
         run: yarn build --no-lint

--- a/app/[category]/[contentPage]/page.tsx
+++ b/app/[category]/[contentPage]/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = 'force-static'
 import { fetchContentPage, fetchContentPages } from '@lib/strapi/contentpage'
 import Page from '@components/Page'
 

--- a/app/api/drive/public/download/route.ts
+++ b/app/api/drive/public/download/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = 'force-dynamic'
 import downloadHandler from '../../downloadHandler'
 import { publicDrive } from '@lib/google/drive'
 

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ error: 'Missing slug' }, { status: 400 })
           }
           revalidatePath(`/${category}/${page}`)
+          revalidateTag('navbar')
           break
         }
         case 'category': {
@@ -48,6 +49,7 @@ export async function POST(request: NextRequest) {
           for (const page of body?.entry?.content_pages) {
             revalidatePath(`/${category}/${page?.slug}`)
           }
+          revalidateTag('navbar')
           break
         }
         case 'content-section': {
@@ -73,6 +75,14 @@ export async function POST(request: NextRequest) {
           const post = body?.entry?.slug
           revalidatePath(`/nyheter/${post}`)
           revalidatePath('/')
+          break
+        }
+        case 'navbar': {
+          revalidateTag('navbar')
+          break
+        }
+        case 'private-page': {
+          revalidateTag('navbar')
           break
         }
         default:

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -85,6 +85,11 @@ export async function POST(request: NextRequest) {
           revalidateTag('navbar')
           break
         }
+        case 'homepage': {
+          revalidatePath('/')
+          break
+        }
+
         default:
           return NextResponse.json({ error: 'Invalid model' }, { status: 400 })
       }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -89,6 +89,10 @@ export async function POST(request: NextRequest) {
           revalidatePath('/')
           break
         }
+        case 'footer': {
+          revalidateTag('footer')
+          break
+        }
 
         default:
           return NextResponse.json({ error: 'Invalid model' }, { status: 400 })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import SessionProvider from '@components/SessionProvider'
 import Header from '@components/header'
 import getNavbar from '@lib/strapi/navbar'
 import Footer from '@components/footer'
-import { fetchHomepage } from '@lib/strapi/homepage'
+import { fetchFooter } from '@lib/strapi/footer'
 
 import '@styles/globals.css'
 import '@styles/links.css'
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
 const RootLayout = async ({ children }: { children: React.ReactNode }) => {
   const session = await getServerSession()
   const navbarLinks = await getNavbar()
-  const homepage = await fetchHomepage()
+  const footer = await fetchFooter()
 
   return (
     <html lang="sv">
@@ -58,7 +58,7 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
           <Header navbarLinks={navbarLinks} />
           <main>{children}</main>
         </SessionProvider>
-        <Footer footer={homepage?.footer} />
+        <Footer nationlogos={footer?.nationlogos} />
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,16 +6,12 @@ import { PostType } from '@models/post'
 import MainBanner, { BannerImage } from '@components/banner/Banner'
 import TFInfo from '@components/TFInfo'
 import Posts from '@components/posts'
-import { NationLogo } from '@components/footer/Logos'
 
 export type Homepage = {
   banner?: {
     bannerImages?: {
       data: BannerImage[]
     }
-  }
-  footer?: {
-    nationlogos?: NationLogo[]
   }
 }
 

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -1,14 +1,16 @@
 import Column from '../Column'
 import NationsLogos from './Logos'
 import BasicInfo from './BasicInfo'
-import { Homepage } from '../../app/page'
+import { NationLogo } from '@components/footer/Logos'
 
-export type FooterProps = Pick<Homepage, 'footer'>
+export type FooterType = {
+  nationlogos?: NationLogo[]
+}
 
-const Footer = async ({ footer }: FooterProps) => (
+const Footer = async ({ nationlogos }: FooterType) => (
   <footer>
     <Column className="sticky bottom-0 w-full bg-darkgray py-5">
-      <NationsLogos nationLogos={footer?.nationlogos ?? []} />
+      <NationsLogos nationLogos={nationlogos ?? []} />
       <BasicInfo />
     </Column>
   </footer>

--- a/lib/strapi/footer.ts
+++ b/lib/strapi/footer.ts
@@ -1,0 +1,14 @@
+import { FooterType } from '@components/footer'
+import qs from 'qs'
+import { fetchSingle } from '@lib/strapi/index'
+
+export async function fetchFooter(): Promise<FooterType | null> {
+  const query = qs.stringify(
+    {
+      populate: ['nationlogos', 'nationlogos.image'],
+    },
+    { encodeValuesOnly: true }
+  )
+  const res = await fetchSingle<FooterType>('/footer', { query })
+  return res?.data?.attributes ?? null
+}

--- a/lib/strapi/footer.ts
+++ b/lib/strapi/footer.ts
@@ -9,6 +9,9 @@ export async function fetchFooter(): Promise<FooterType | null> {
     },
     { encodeValuesOnly: true }
   )
-  const res = await fetchSingle<FooterType>('/footer', { query })
+  const res = await fetchSingle<FooterType>('/footer', {
+    query,
+    tags: ['footer'],
+  })
   return res?.data?.attributes ?? null
 }

--- a/lib/strapi/homepage.ts
+++ b/lib/strapi/homepage.ts
@@ -5,13 +5,7 @@ import { fetchSingle } from '@lib/strapi/index'
 export async function fetchHomepage(): Promise<Homepage | null> {
   const query = qs.stringify(
     {
-      populate: [
-        'banner',
-        'banner.bannerImages',
-        'footer',
-        'footer.nationlogos',
-        'footer.nationlogos.image',
-      ],
+      populate: ['banner', 'banner.bannerImages'],
     },
     { encodeValuesOnly: true }
   )

--- a/lib/strapi/navbar.ts
+++ b/lib/strapi/navbar.ts
@@ -57,7 +57,10 @@ export default async function fetchNavbar(): Promise<NavbarLink[]> {
     },
     { encodeValuesOnly: true }
   )
-  const res = await fetchSingle<Navbar>('/navbar', { query })
+  const res = await fetchSingle<Navbar>('/navbar', {
+    query,
+    tags: ['navbar'],
+  })
 
   if (res === null || res?.data === null) return []
 


### PR DESCRIPTION
* Separate footer from homepage query
  * Related strapi change deployed already
* Allow passing tags (used by revalidateTag) when fetching from strapi
* Revalidate footer & homepage on strapi change
* Revalidate navbar on all page, category and link changes
* Fix some build errors related to app router handling of dynamic / static routes